### PR TITLE
Edmundo_Drift

### DIFF
--- a/Neutral_simulations/CLM/admix_sim_CLM.R
+++ b/Neutral_simulations/CLM/admix_sim_CLM.R
@@ -1,7 +1,7 @@
 library(data.table)
 library(ggplot2)
 
-#write function to simulate variation in local ancestry
+#write function to simulate variation in local ancestry (over certain 'g' generations and 'nind' # of individuals)
 sim.admix<-function(a0,b0,c0,g,nind=1250){
   nchrom<-nind*2
   nchrom.a0<-a0*nchrom
@@ -30,12 +30,13 @@ sim.admix<-function(a0,b0,c0,g,nind=1250){
 
 
 #read local ancestry frequency for the population of interest
-avg.lanc<-fread('lanc_popavg_CLM.txt',sep="\t",header=T)
+avg.lanc<-fread('./Neutral_simulations/CLM/lanc_popavg_CLM.txt',sep="\t",header=T)
 avg.lanc$hg19chr<-paste("chr",avg.lanc$chr,sep="")
 
-#subsample 1000 loci
+#subsample 10000 loci
 avg.lanc.red<-avg.lanc[sample(nrow(avg.lanc),10000),]
 
+#Simulate variation in local ancestry in Colombian (CLM) population over 14 generations with N=1250.
 output<-as.data.frame(t(replicate(10000,sim.admix(mean(avg.lanc.red$afr.lanc),mean(avg.lanc.red$eur.lanc),mean(avg.lanc.red$nat.lanc),14))))
 colnames(output)<-c("African","European","Native_American")
 
@@ -72,7 +73,7 @@ ggsave("qq_autosomal_CLM.pdf",qq.plot,height=5,width=10)
 
 
 #loading sex specific ancestry contributions for each population
-mf.props<-read.table("../../Sex_bias_estimation//sex_spec_ancestry_contribs_avg.txt",header=T)
+mf.props<-read.table("./Sex_bias_estimation/sex_spec_ancestry_contribs_avg.txt",header=T)
 mf.clm<-mf.props[which(mf.props$admx.pop=="CLM" & mf.props$sex=="f"),]
 
 #write function to simulate variation in mtDNA given proportion of females
@@ -101,15 +102,15 @@ sim.mt<-function(af,bf,cf,g,nind=1250){
   return(c(nchrom.af,nchrom.bf,nchrom.cf)/nchrom)
 }
 
-#simulate
+#simulate variation in mtDNA
 mt.sim.dat<-as.data.frame(t(replicate(10000,sim.mt(mf.clm$proportion[3],mf.clm$proportion[2],mf.clm$proportion[3],14))))
 colnames(mt.sim.dat)<-c("African","European","Native_American")
 
 #read observed mt frequencies
-mt.obs.dat<-read.table("../../Data_tables//mtprop_table.txt",header=T)
+mt.obs.dat<-read.table("./Data_tables//mtprop_table.txt",header=T)
 mt.obs.pur<-mt.obs.dat[which(mt.obs.dat$Population=="CLM"),]
 
-#plt simulated data against observed mt haplogroup freuency
+#plt simulated data against observed mt haplogroup frequency
 mt.sim.dat<-melt(mt.sim.dat)
 colnames(mt.sim.dat)<-c("Ancestry","sim.f")
 

--- a/Neutral_simulations/PUR/admix_sims.R
+++ b/Neutral_simulations/PUR/admix_sims.R
@@ -1,6 +1,8 @@
 library(data.table)
 library(ggplot2)
 
+##setwd("/Users/edmtorres/Documents/GitHub/Mito_nuclear_incompatibility")
+
 #write function to simulate variation in local ancestry
 sim.admix<-function(a0,b0,c0,g,nind=1250){
   nchrom<-nind*2
@@ -30,7 +32,7 @@ sim.admix<-function(a0,b0,c0,g,nind=1250){
 
 
 #read local ancestry frequency for the population of interest
-avg.lanc<-fread('/Users/edmtorres/Documents/GitHub/Mito_nuclear_incompatibility/Neutral_simulations/PUR/lanc_popavg_PUR.txt',sep="\t",header=T)
+avg.lanc<-fread('./Neutral_simulations/PUR/lanc_popavg_PUR.txt',sep="\t",header=T)
 avg.lanc$hg19chr<-paste("chr",avg.lanc$chr,sep="")
 
 #subsample 10000 loci
@@ -72,7 +74,7 @@ ggsave("qq_autosomal_PUR.pdf",qq.plot,height=5,width=10)
 
 
 #loading sex specific ancestry contributions for each population
-mf.props<-read.table("/Users/edmtorres/Documents/GitHub/Mito_nuclear_incompatibility/Sex_bias_estimation/sex_spec_ancestry_contribs_avg.txt",header=T)
+mf.props<-read.table("./Sex_bias_estimation/sex_spec_ancestry_contribs_avg.txt",header=T)
 mf.pur<-mf.props[which(mf.props$admx.pop=="PUR" & mf.props$sex=="f"),]
 
 #write function to simulate variation in mtDNA given proportion of females
@@ -106,10 +108,10 @@ mt.sim.dat<-as.data.frame(t(replicate(10000,sim.mt(mf.pur$proportion[3],mf.pur$p
 colnames(mt.sim.dat)<-c("African","European","Native_American")
 
 #read observed mt frequencies
-mt.obs.dat<-read.table("~/Documents/mtproj_files/mitonuclear_project/mtnuc_organization/sex_biased_admixture/mtprop_table.txt",header=T)
+mt.obs.dat<-read.table("./Data_tables/mtprop_table.txt",header=T)
 mt.obs.pur<-mt.obs.dat[which(mt.obs.dat$Population=="PUR"),]
 
-#plt simulated data against observed mt haplogroup freuency
+#plt simulated data against observed mt haplogroup frequency
 mt.sim.dat<-melt(mt.sim.dat)
 colnames(mt.sim.dat)<-c("Ancestry","sim.f")
 

--- a/Neutral_simulations/PUR/admix_sims.R
+++ b/Neutral_simulations/PUR/admix_sims.R
@@ -1,4 +1,5 @@
 library(data.table)
+library(ggplot2)
 
 #write function to simulate variation in local ancestry
 sim.admix<-function(a0,b0,c0,g,nind=1250){
@@ -29,10 +30,10 @@ sim.admix<-function(a0,b0,c0,g,nind=1250){
 
 
 #read local ancestry frequency for the population of interest
-avg.lanc<-fread('~/Documents/mtproj_files/mitonuclear_project/mtnuc_organization/lanc_enrichment_in_mtgenes/lanc_popavg_PUR.txt',sep="\t",header=T)
+avg.lanc<-fread('/Users/edmtorres/Documents/GitHub/Mito_nuclear_incompatibility/Neutral_simulations/PUR/lanc_popavg_PUR.txt',sep="\t",header=T)
 avg.lanc$hg19chr<-paste("chr",avg.lanc$chr,sep="")
 
-#subsample 1000 loci
+#subsample 10000 loci
 avg.lanc.red<-avg.lanc[sample(nrow(avg.lanc),10000),]
 
 output<-as.data.frame(t(replicate(10000,sim.admix(mean(avg.lanc.red$afr.lanc),mean(avg.lanc.red$eur.lanc),mean(avg.lanc.red$nat.lanc),17))))
@@ -71,7 +72,7 @@ ggsave("qq_autosomal_PUR.pdf",qq.plot,height=5,width=10)
 
 
 #loading sex specific ancestry contributions for each population
-mf.props<-read.table("~/Documents/mtproj_files/mitonuclear_project/mtnuc_organization/sex_biased_admixture/sex_spec_ancestry_contribs_avg_04272018.txt",header=T)
+mf.props<-read.table("/Users/edmtorres/Documents/GitHub/Mito_nuclear_incompatibility/Sex_bias_estimation/sex_spec_ancestry_contribs_avg.txt",header=T)
 mf.pur<-mf.props[which(mf.props$admx.pop=="PUR" & mf.props$sex=="f"),]
 
 #write function to simulate variation in mtDNA given proportion of females

--- a/Neutral_simulations/PUR/admix_sims.R
+++ b/Neutral_simulations/PUR/admix_sims.R
@@ -1,9 +1,7 @@
 library(data.table)
 library(ggplot2)
 
-##setwd("/Users/edmtorres/Documents/GitHub/Mito_nuclear_incompatibility")
-
-#write function to simulate variation in local ancestry
+#write function to simulate variation in local ancestry (over certain 'g' generations and 'nind' # of individuals)
 sim.admix<-function(a0,b0,c0,g,nind=1250){
   nchrom<-nind*2
   nchrom.a0<-a0*nchrom
@@ -38,6 +36,7 @@ avg.lanc$hg19chr<-paste("chr",avg.lanc$chr,sep="")
 #subsample 10000 loci
 avg.lanc.red<-avg.lanc[sample(nrow(avg.lanc),10000),]
 
+#Simulate variation in local ancestry in Puerto Rican (PUR) population over 17 generations with N=1250.
 output<-as.data.frame(t(replicate(10000,sim.admix(mean(avg.lanc.red$afr.lanc),mean(avg.lanc.red$eur.lanc),mean(avg.lanc.red$nat.lanc),17))))
 colnames(output)<-c("African","European","Native_American")
 
@@ -103,7 +102,7 @@ sim.mt<-function(af,bf,cf,g,nind=1250){
   return(c(nchrom.af,nchrom.bf,nchrom.cf)/nchrom)
 }
 
-#simulate
+#simulate variation in mtDNA
 mt.sim.dat<-as.data.frame(t(replicate(10000,sim.mt(mf.pur$proportion[3],mf.pur$proportion[2],mf.pur$proportion[3],17))))
 colnames(mt.sim.dat)<-c("African","European","Native_American")
 


### PR DESCRIPTION
These contain suggested updates to the Neutral_Simulations folder which contains the scripts for 'Simulation of drift since admixture'.
I updated the paths so that they show where the needed input files are.
Some comments were expanded for clarity.
Also, I made sure to make similar changes to both PUR and CLM scripts so that they would be easy to compare.