### PR TITLE
Changes to MT copy number calculation files

### DIFF
--- a/mtDNA_copynumber/Calculating_copyn/Association_bw_ancestry_and_copyn/Cal_med_copyn_06012018.R
+++ b/mtDNA_copynumber/Calculating_copyn/Association_bw_ancestry_and_copyn/Cal_med_copyn_06012018.R
@@ -1,22 +1,22 @@
 library(ggplot2)
 library(plyr)
 
-#setwd("~/Documents/mtproj_files/mitonuclear_project/mtnuc_organization/Copy_number/copyn_analysis_06012018/")
+#setwd("~/Mito_nuclear_incompatibility/mtDNA_copynumber/Calculating_copyn/Association_bw_ancestry_and_copyn")
 
-ceu.copyn<-read.table("../Low_coverage/CEU/CEU.header.mtdna_no",header=T,sep="\t")
-yri.copyn<-read.table("../Low_coverage/YRI/YRI.header.mtdna_no",header=T,sep="\t")
-admx.copyn<-read.table("../Low_coverage/Americans_lowcov.mtdna_no/Americans_lowcov.mtdna_no",header=F,sep="\t")
+ceu.copyn<-read.table("../Calculating_copyn/Low_coverage/CEU/CEU.header.mtdna_no",header=T,sep="\t")
+yri.copyn<-read.table("../Calculating_copyn/Low_coverage/YRI/YRI.header.mtdna_no",header=T,sep="\t")
+admx.copyn<-read.table("../Calculating_copyn/Low_coverage/Admixed_Americans/Americans_lowcov.mtdna_no",header=F,sep="\t")
 colnames(admx.copyn)<-colnames(ceu.copyn)
 
 
 ceu.copyn$pop<-"CEU"
 yri.copyn$pop<-"YRI"
 
-admx.pop<-read.table("../../../Data_tables/pop_1kg.txt",header=T,sep="\t")
+admx.pop<-read.table("../../Data_tables/pop_1kg.txt",header=T,sep="\t")
 admx.copyn<-join(admx.copyn,admx.pop[,c("IID","pop")])
 
 all.copyn<-rbind(ceu.copyn,yri.copyn,admx.copyn)
-#remove samples with less than 250 mtdna_nopyn - these are blood samples
+#remove samples with less than 250 mtdna_copyn - these are blood samples
 
 
 #parent.copyn<-rbind(ceu.copyn,yri.copyn)

--- a/mtDNA_copynumber/Calculating_copyn/Association_bw_ancestry_and_copyn/ancestry_mtcopyn_association.R
+++ b/mtDNA_copynumber/Calculating_copyn/Association_bw_ancestry_and_copyn/ancestry_mtcopyn_association.R
@@ -8,7 +8,7 @@ library(gridExtra)
 mt.copyn<-read.table("mtdna_copyn_allsamples_06012018.txt",header=T,sep="\t")
 
 #load info about DNA source
-DNAsrc<-read.table("../../../Data_tables/1kg_DNAsource.txt",header=T,sep="\t")
+DNAsrc<-read.table("../../Data_tables/1kg_DNAsource.txt",header=T,sep="\t")
 colnames(DNAsrc)<-c("IID","pop","ebv.cvrg","dna.source","has.blood")
 
 #add source info
@@ -28,15 +28,15 @@ ggsave('lowcov_mtdna_copyn_distribution_06012018.pdf',plt,height=5,width=10)
 mt.copyn<-mt.copyn[which(mt.copyn$med.mtcopyn>250),]
 
 #read global ancestry for these people
-qfile<-read.table("../../../ADMIXTURE_ancestry/Autosome/1kg_nam_flipped.3.Q",header=F)
+qfile<-read.table("../../ADMIXTURE_ancestry/Autosome/1kg_nam_flipped.3.Q",header=F)
 #read fam file corresponding to the qfile
-fam<-read.table("../../../ADMIXTURE_ancestry/Autosome/1kg_nam_flipped.fam",header=F)
+fam<-read.table("../../ADMIXTURE_ancestry/Autosome/1kg_nam_flipped.fam",header=F)
 fam<-fam[,c(1:2)]
 colnames(fam)<-c("FID","IID")
 global.anc<-cbind(fam,qfile)
 
 #read pop file
-pop.file<-read.table("../../../Data_tables/pop_1kg.txt",header=T)
+pop.file<-read.table("../../Data_tables/pop_1kg.txt",header=T)
 #add pop info to global.anc file
 global.anc<-join(global.anc,pop.file,by="IID")
 
@@ -48,7 +48,7 @@ mt.copyn.anc<-join(mt.copyn[,c(1,3)],global.anc,by="IID")
 
 #load mthaplogroup info
 #load haplogroup information 
-mt.haplo<-read.table("../../../Data_tables/AMR_mt.haplo",header=T,sep="\t")
+mt.haplo<-read.table("../../Data_tables/AMR_mt.haplo",header=T,sep="\t")
 colnames(mt.haplo)<-c("IID","Sex","Population","major_haplogroup")
 #group haplo into regional categories
 mt.haplo$region_haplogroup<-NA

--- a/mtDNA_copynumber/Calculating_copyn/Comparison_bw_high_and_low_coverage/extract_copy_no.sh
+++ b/mtDNA_copynumber/Calculating_copyn/Comparison_bw_high_and_low_coverage/extract_copy_no.sh
@@ -1,36 +1,23 @@
 #!/bin/bash
 
-#SBATCH -C new
-##SBATCH --cpus-per-task=8
-#SBATCH -J DNAdamage
-#SBATCH -t 14-00:00:00
-#SBATCH --mail-type=ALL
-#SBATCH --mail-user=saz5078@psu.edu
-#SBATCH -e slurm-%j.err
-#SBATCH -D /nfs/brubeck.bx.psu.edu/scratch3/arslan/mtnuc_project/copy_number
-
-
-source /nfs/brubeck.bx.psu.edu/scratch4/arslan/.bash_profile
-source activate cenv
-
 location=ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/phase3/data
 iid=${1}
 bam=${2}
+coverage=${3}
+# low coverage = "alignment", high coverage = "high_coverage_alignment"
 
-alignment=${location}/${iid}/alignment/${bam}
-index=${location}/${iid}/alignment/${bam}.bai
+alignment=${location}/${iid}/${coverage}/${bam}
+index=${location}/${iid}/${coverage}/${bam}.bai
 
 read_length=`samtools view ${alignment} |head -n 1000 |awk '{sum+=length($10)} END{print sum/NR}'`
 echo $read_length
 echo "running idxstats"
 
-cd /nfs/brubeck.bx.psu.edu/scratch3/arslan/mtnuc_project/copy_number
-
-samtools idxstats ${alignment} > ${iid}.idxstats
+samtools idxstats ${alignment} > ${coverage}/idxstats/${iid}.idxstats
 
 echo "calculating depth of sequencing"
 
-Rscript cal_mtdna_copy.R ${iid}.idxstats ${read_length}
+Rscript cal_mtdna_copy.R ${coverage}/idxstats/${iid}.idxstats ${read_length}
 
 
 

--- a/mtDNA_copynumber/Calculating_copyn/Low_coverage/extract_copy_no.sh
+++ b/mtDNA_copynumber/Calculating_copyn/Low_coverage/extract_copy_no.sh
@@ -1,18 +1,5 @@
 #!/bin/bash
 
-#SBATCH -C new
-##SBATCH --cpus-per-task=8
-#SBATCH -J DNAdamage
-#SBATCH -t 14-00:00:00
-#SBATCH --mail-type=ALL
-#SBATCH --mail-user=saz5078@psu.edu
-#SBATCH -e slurm-%j.err
-#SBATCH -D /nfs/brubeck.bx.psu.edu/scratch3/arslan/mtnuc_project/copy_number
-
-
-source /nfs/brubeck.bx.psu.edu/scratch4/arslan/.bash_profile
-source activate cenv
-
 location=ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/phase3/data
 iid=${1}
 bam=${2}
@@ -21,10 +8,9 @@ alignment=${location}/${iid}/alignment/${bam}
 index=${location}/${iid}/alignment/${bam}.bai
 
 read_length=`samtools view ${alignment} |head -n 1000 |awk '{sum+=length($10)} END{print sum/NR}'`
+#Counts DNA string/read in 10th column of SAM file in the first 1000 reads present.
 echo $read_length
 echo "running idxstats"
-
-cd /nfs/brubeck.bx.psu.edu/scratch3/arslan/mtnuc_project/copy_number
 
 samtools idxstats ${alignment} > ${iid}.idxstats
 


### PR DESCRIPTION
Most changes to the scripts update the paths to match the current folder structure.

One important change is in the comparison between different coverages. Added a third argument to the bash script that distinguishes between high and low coverage alignments.

Also deleted settings that are specific to the BX cluster, and commands that were specific to your computes or earlier folder structure.